### PR TITLE
add release name to info

### DIFF
--- a/recipe/deploy/info.php
+++ b/recipe/deploy/info.php
@@ -3,5 +3,5 @@ namespace Deployer;
 
 desc('Displays info about deployment');
 task('deploy:info', function () {
-    info("deploying <fg=magenta;options=bold>{{target}}</>");
+    info("deploying <fg=magenta;options=bold>{{target}}</> (release <fg=magenta;options=bold>{{release_name}}</>)");
 });


### PR DESCRIPTION
I always find myself adding a task to just show the release name.
Why not add it to the built-in `info` task?